### PR TITLE
Add DownloadedArtifactInfo with LocalName and size - this is what Loaders and Extractors accept as arg now

### DIFF
--- a/sources/file_system_source_test.go
+++ b/sources/file_system_source_test.go
@@ -21,7 +21,7 @@ type testObserver struct {
 func (t *testObserver) Notify(ctx context.Context, e events.Event) error {
 	switch ty := e.(type) {
 	case *events.ArtifactDiscovered:
-		t.Artifacts = append(t.Artifacts, ty.Info.OriginalName)
+		t.Artifacts = append(t.Artifacts, ty.Info.Name)
 	}
 	return nil
 }


### PR DESCRIPTION
Rename ArtifactInfo OriginalName to Name
Pass latest artifact path, downloaded bytes and rows received in status messages